### PR TITLE
Fix regex to skip empty tags

### DIFF
--- a/file.go
+++ b/file.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	rComment = regexp.MustCompile(`^//\s*@inject_tag:\s*(?P<tag>.*)$`)
+	rComment = regexp.MustCompile(`^//\s*@inject_tag:\s*(?P<tag>\S+)$`)
 	rInject  = regexp.MustCompile("`$")
 )
 
@@ -62,6 +62,9 @@ func parseFile(inputPath string) (areas []textArea, err error) {
 			}
 			for _, comment := range field.Doc.List {
 				tag := tagFromComment(comment.Text)
+				if tag == "" {
+					continue
+				}
 				area := textArea{
 					Start: int(field.Pos()),
 					End:   int(field.End()),

--- a/file.go
+++ b/file.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	rComment = regexp.MustCompile(`^//\s*@inject_tag:\s*(?P<tag>\S+)$`)
+	rComment = regexp.MustCompile(`^//\s*@inject_tag:\s*(\S+)$`)
 	rInject  = regexp.MustCompile("`$")
 )
 


### PR DESCRIPTION
I file this pr to fix an issue I've encountered as follows.

I have a `pay.proto` file like this:

```
message Payment {
    int32 error = 1;
    string transactionID = 2;
    string productID = 3;
    int32 points = 4;
    // expiry is the timestamp for subscription expired time
    int32 expiry = 5;
}
```

The protoc-generated `pay.pb.go` file will be like this:

```
type Payment struct {
	Error         int32  `protobuf:"varint,1,opt,name=error" json:"error"`
	TransactionID string `protobuf:"bytes,2,opt,name=transactionID" json:"transactionID"`
	ProductID     string `protobuf:"bytes,3,opt,name=productID" json:"productID"`
	Points        int32  `protobuf:"varint,4,opt,name=points" json:"points"`
	// expiry is the timestamp for subscription expired time
	Expiry int32 `protobuf:"varint,5,opt,name=expiry" json:"expiry"`
}
```

Then I used `protoc-go-inject-tag` to re-generate `pay.pb.go`. And the console output:

```
2017/05/05 22:55:38 parsing file "./models/pay.pb.go" for inject tag comments
2017/05/05 22:55:38 parsed file "./models/pay.pb.go", number of fields to inject custom tags: 1
2017/05/05 22:55:38 inject custom tag "" to expression "Expiry int32 `protobuf:\"varint,5,opt,name=expiry\" json:\"expiry\"`"
2017/05/05 22:55:38 file "./models/pay.pb.go" is injected with custom tags
```

The final `pay.gb.go` file:

```
type Payment struct {
	Error         int32  `protobuf:"varint,1,opt,name=error" json:"error"`
	TransactionID string `protobuf:"bytes,2,opt,name=transactionID" json:"transactionID"`
	ProductID     string `protobuf:"bytes,3,opt,name=productID" json:"productID"`
	Points        int32  `protobuf:"varint,4,opt,name=points" json:"points"`
	// expiry is the timestamp for subscription expired time
	Expiry int32 `protobuf:"varint,5,opt,name=expiry" json:"expiry" `
}
```

There is an extra whitespace after `json:"expiry"`.

The solution I proposed is to skip result of function `tagFromComment` since there is an empty string returned even comment not matched.

The other part of this pr is to fix regex `rComment`. The original one will match comment like this:

```
// @inject_tag:
```

So I replace `.*` with `\S+` to match any string not containing whitespace. And the used named group `?P<tag>` is also removed.