### PR TITLE
Skip log while no injection

### DIFF
--- a/file.go
+++ b/file.go
@@ -100,6 +100,8 @@ func writeFile(inputPath string, areas []textArea) (err error) {
 		return
 	}
 
-	log.Printf("file %q is injected with custom tags", inputPath)
+	if len(areas) > 0 {
+		log.Printf("file %q is injected with custom tags", inputPath)
+	}
 	return
 }


### PR DESCRIPTION
The third line should be skipped while tag count is 0.

```
2017/05/05 23:26:25 parsing file "models/money/money.pb.go" for inject tag comments
2017/05/05 23:26:25 parsed file "models/money/money.pb.go", number of fields to inject custom tags: 0
2017/05/05 23:26:25 file "models/money/money.pb.go" is injected with custom tags
```