### PR TITLE
skipped if field.Names == nil

### DIFF
--- a/file.go
+++ b/file.go
@@ -71,16 +71,18 @@ func parseFile(inputPath string, xxxSkip []string) (areas []textArea, err error)
 
 		for _, field := range structDecl.Fields.List {
 			// skip if field has no doc
-			name := field.Names[0].Name
-			if len(xxxSkip) > 0 && strings.HasPrefix(name, "XXX") {
-				currentTag := field.Tag.Value
-				area := textArea{
-					Start:      int(field.Pos()),
-					End:        int(field.End()),
-					CurrentTag: currentTag[1 : len(currentTag)-1],
-					InjectTag:  builder.String(),
+			if len(field.Names) > 0 {
+				name := field.Names[0].Name
+				if len(xxxSkip) > 0 && strings.HasPrefix(name, "XXX") {
+					currentTag := field.Tag.Value
+					area := textArea{
+						Start:      int(field.Pos()),
+						End:        int(field.End()),
+						CurrentTag: currentTag[1 : len(currentTag)-1],
+						InjectTag:  builder.String(),
+					}
+					areas = append(areas, area)
 				}
-				areas = append(areas, area)
 			}
 			if field.Doc == nil {
 				continue


### PR DESCRIPTION
On my machine it can happen that len(field.Names) == 0. In this case an out of range exception is thrown. This branch is a possible fix for this. 
Thank you for looking into this. 