### PR TITLE
Add flag for verbose logging, off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ type IP struct {
 
 To skip the tag for the generated XXX_* fields, use
 `-XXX_skip=yaml,xml` flag.
+
+To enable verbose logging, use `-verbose`

--- a/file.go
+++ b/file.go
@@ -25,8 +25,10 @@ type textArea struct {
 	InjectTag  string
 }
 
-func parseFile(inputPath string, xxxSkip []string) (areas []textArea, err error) {
-	log.Printf("parsing file %q for inject tag comments", inputPath)
+func parseFile(inputPath string, xxxSkip []string, verbose bool) (areas []textArea, err error) {
+	if verbose {
+		log.Printf("parsing file %q for inject tag comments", inputPath)
+	}
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, inputPath, nil, parser.ParseComments)
 	if err != nil {
@@ -103,11 +105,13 @@ func parseFile(inputPath string, xxxSkip []string) (areas []textArea, err error)
 			}
 		}
 	}
-	log.Printf("parsed file %q, number of fields to inject custom tags: %d", inputPath, len(areas))
+	if verbose {
+		log.Printf("parsed file %q, number of fields to inject custom tags: %d", inputPath, len(areas))
+	}
 	return
 }
 
-func writeFile(inputPath string, areas []textArea) (err error) {
+func writeFile(inputPath string, areas []textArea, verbose bool) (err error) {
 	f, err := os.Open(inputPath)
 	if err != nil {
 		return
@@ -125,14 +129,16 @@ func writeFile(inputPath string, areas []textArea) (err error) {
 	// inject custom tags from tail of file first to preserve order
 	for i := range areas {
 		area := areas[len(areas)-i-1]
-		log.Printf("inject custom tag %q to expression %q", area.InjectTag, string(contents[area.Start-1:area.End-1]))
+		if verbose {
+			log.Printf("inject custom tag %q to expression %q", area.InjectTag, string(contents[area.Start-1:area.End-1]))
+		}
 		contents = injectTag(contents, area)
 	}
 	if err = ioutil.WriteFile(inputPath, contents, 0644); err != nil {
 		return
 	}
 
-	if len(areas) > 0 {
+	if len(areas) > 0 && verbose {
 		log.Printf("file %q is injected with custom tags", inputPath)
 	}
 	return

--- a/main.go
+++ b/main.go
@@ -9,8 +9,10 @@ import (
 func main() {
 	var inputFile string
 	var xxxTags string
+	var verbose bool
 	flag.StringVar(&inputFile, "input", "", "path to input file")
 	flag.StringVar(&xxxTags, "XXX_skip", "", "skip tags to inject on XXX fields")
+	flag.BoolVar(&verbose, "verbose", false, "verbose logging")
 
 	flag.Parse()
 
@@ -23,11 +25,11 @@ func main() {
 		log.Fatal("input file is mandatory")
 	}
 
-	areas, err := parseFile(inputFile, xxxSkipSlice)
+	areas, err := parseFile(inputFile, xxxSkipSlice, verbose)
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err = writeFile(inputFile, areas); err != nil {
+	if err = writeFile(inputFile, areas, verbose); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -35,7 +35,7 @@ func TestTagFromComment(t *testing.T) {
 func TestParseWriteFile(t *testing.T) {
 	expectedTag := `valid:"ip" yaml:"ip" json:"overrided"`
 
-	areas, err := parseFile(testInputFile, []string{})
+	areas, err := parseFile(testInputFile, []string{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestParseWriteFile(t *testing.T) {
 	}
 	defer os.Remove(testInputFileTemp)
 
-	if err = writeFile(testInputFileTemp, areas); err != nil {
+	if err = writeFile(testInputFileTemp, areas, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -108,7 +108,7 @@ func TestNewTagItems(t *testing.T) {
 func TestContinueParsingWhenSkippingFields(t *testing.T) {
 	expectedTags := []string{`valid:"ip" yaml:"ip" json:"overrided"`, `xml:"-"`, `xml:"-"`, `xml:"-"`, `valid:"http|https"`, `valid:"nonzero"`, `xml:"-"`, `xml:"-"`, `xml:"-"`}
 
-	areas, err := parseFile(testInputFile, []string{"xml"})
+	areas, err := parseFile(testInputFile, []string{"xml"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestContinueParsingWhenSkippingFields(t *testing.T) {
 	}
 	defer os.Remove(testInputFileTemp)
 
-	if err = writeFile(testInputFileTemp, areas); err != nil {
+	if err = writeFile(testInputFileTemp, areas, false); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This turns logging off by default.
Passing in the `-verbose` flag will turn it back on.