### PR TITLE
Allow comments prefixing the injection tag

### DIFF
--- a/file.go
+++ b/file.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	rComment = regexp.MustCompile(`^//\s*@inject_tag:\s*(.*)$`)
+	rComment = regexp.MustCompile(`^//.*?@inject_tag:\s*(.*)$`)
 	rInject  = regexp.MustCompile("`.+`$")
 	rTags    = regexp.MustCompile(`[\w_]+:"[^"]+"`)
 )

--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,7 @@ func TestTagFromComment(t *testing.T) {
 		{comment: `// fdsafsa`, tag: ""},
 		{comment: `//@inject_tag:`, tag: ""},
 		{comment: `// @inject_tag: json:"abc" yaml:"abc`, tag: `json:"abc" yaml:"abc`},
+		{comment: `// test @inject_tag: json:"abc" yaml:"abc`, tag: `json:"abc" yaml:"abc`},
 	}
 	for _, test := range tests {
 		result := tagFromComment(test.comment)


### PR DESCRIPTION
Allow any characters between the start of the comment, up until the start characters for tag injection. I don't see this being an issue, and should help in the situations where there are other generated comments.

closes #25