### PR TITLE
fix: tags when using trailing + regular comments

### DIFF
--- a/file.go
+++ b/file.go
@@ -88,10 +88,16 @@ func parseFile(inputPath string, xxxSkip []string) (areas []textArea, err error)
 
 			if field.Doc != nil {
 				comments = append(comments, field.Doc.List...)
-			} else if field.Comment != nil {
+			}
+
+			// The "doc" field (above comment) is more commonly "free-form"
+			// due to the ability to have a much larger comment without it
+			// being unwieldly. As such, the "comment" field (trailing comment),
+			// should take precedence if there happen to be multiple tags
+			// specified, both in the field doc, and the field line. Whichever
+			// comes last, will take precedence.
+			if field.Comment != nil {
 				comments = append(comments, field.Comment.List...)
-			} else {
-				continue
 			}
 
 			for _, comment := range comments {

--- a/main_test.go
+++ b/main_test.go
@@ -42,8 +42,8 @@ func TestParseWriteFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(areas) != 8 {
-		t.Fatalf("expected 8 areas to replace, got: %d", len(areas))
+	if len(areas) != 9 {
+		t.Fatalf("expected 9 areas to replace, got: %d", len(areas))
 	}
 	area := areas[0]
 	t.Logf("area: %v", area)
@@ -112,6 +112,7 @@ func TestNewTagItems(t *testing.T) {
 func TestContinueParsingWhenSkippingFields(t *testing.T) {
 	expectedTags := []string{
 		`valid:"ip" yaml:"ip" json:"overrided"`,
+		`valid:"-"`,
 		`valid:"http|https"`,
 		`valid:"nonzero"`,
 		`validate:"omitempty"`,

--- a/pb/test.pb.go
+++ b/pb/test.pb.go
@@ -74,8 +74,13 @@ type URL struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// @inject_tag: valid:"http|https"
-	Scheme string `protobuf:"bytes,1,opt,name=scheme,proto3" json:"scheme,omitempty"`
+	// below is an example where the line-specific comment should take precedence
+	// over the "doc" comment, which is known to be more free-form. On the
+	// resulting struct field, you should see `valid:"http|https"` added, not
+	// `valid:"-"`.
+	//
+	// @inject_tag: valid:"-"
+	Scheme string `protobuf:"bytes,1,opt,name=scheme,proto3" json:"scheme,omitempty"` // @inject_tag: valid:"http|https"
 	Url    string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
 	// @inject_tag: valid:"nonzero"
 	Port int32 `protobuf:"varint,3,opt,name=port,proto3" json:"port,omitempty"`

--- a/pb/test.proto
+++ b/pb/test.proto
@@ -11,8 +11,13 @@ message IP {
 }
 
 message URL {
-  // @inject_tag: valid:"http|https"
-  string scheme = 1;
+  // below is an example where the line-specific comment should take precedence
+  // over the "doc" comment, which is known to be more free-form. On the
+  // resulting struct field, you should see `valid:"http|https"` added, not
+  // `valid:"-"`.
+  //
+  // @inject_tag: valid:"-"
+  string scheme = 1; // @inject_tag: valid:"http|https"
   string url = 2;
   // @inject_tag: valid:"nonzero"
   int32 port = 3;


### PR DESCRIPTION
This PR fixes an issue with the new trailing comment functionality that I didn't take into consideration when first implementing it.

When you have the following configuration:
```proto
message URL {
  // scheme defines what protocol schema should be used (e.g. http, https, etc).
  string scheme = 1; // @inject_tag: valid:"http|https"
  [...]
}
```

This would cause no tags to be added, because if any comment (even one without tags) was defined in the `Doc` struct field, it wouldn't try and parse the trailing comments.

This PR does two things:

- Fixes the above issue, so you can still have a regular comment in the `Doc` field, and have trailing tags defined.
- If tags are defined in both locations, the trailing comment takes precedence.