### PR TITLE
Add support for (and recommend as the new default) @gotags field

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ injected into the resulting `.pb.go` file. This can be specified above the
 field, or trailing the field.
 
 ```proto
-// @inject_tag: custom_tag:"custom_value"
+// @gotags: custom_tag:"custom_value"
 ```
 
 ## Example
@@ -57,11 +57,11 @@ package pb;
 option go_package = "/pb";
 
 message IP {
-  // @inject_tag: valid:"ip"
+  // @gotags: valid:"ip"
   string Address = 1;
 
   // Or:
-  string MAC = 2; // @inject_tag: validate:"omitempty"
+  string MAC = 2; // @gotags: validate:"omitempty"
 }
 ```
 
@@ -83,13 +83,22 @@ The custom tags will be injected to `test.pb.go`:
 
 ```go
 type IP struct {
-	// @inject_tag: valid:"ip"
+	// @gotags: valid:"ip"
 	Address string `protobuf:"bytes,1,opt,name=Address,json=address" json:"Address,omitempty" valid:"ip"`
 }
 ```
 
-To skip the tag for the generated XXX\_\* fields (unknown fields), use the
-`-XXX_skip=yaml,xml` flag. Note that this is deprecated, as this functionality
-hasn't existed in `protoc-gen-go` since v1.4.x.
+## Deprecated functionality
 
-To enable verbose logging, use `-verbose`.
+#### Skip `XXX_*` fields
+
+To skip the tag for the generated `XXX_*` fields (unknown fields), use the
+`-XXX_skip=yaml,xml` flag. This is deprecated, as this functionality hasn't
+existed in `protoc-gen-go` since v1.4.x.
+
+#### `inject_tag` keyword
+
+Since **v1.3.0**, we recommend using `@gotags:` rather than `@inject_tags:`,
+as `@gotags` is more indicative of the language the comment is for. We don't
+plan on removing `@inject_tags:` support anytime soon, however we strongly
+recommend switching to `@gotags`.

--- a/file.go
+++ b/file.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	rComment = regexp.MustCompile(`^//.*?@inject_tag:\s*(.*)$`)
+	rComment = regexp.MustCompile(`^//.*?@(?i:gotags?|inject_tags?):\s*(.*)$`)
 	rInject  = regexp.MustCompile("`.+`$")
 	rTags    = regexp.MustCompile(`[\w_]+:"[^"]+"`)
 )
@@ -105,6 +105,11 @@ func parseFile(inputPath string, xxxSkip []string) (areas []textArea, err error)
 				if tag == "" {
 					continue
 				}
+
+				if strings.Contains(comment.Text, "inject_tag") {
+					logf("warn: deprecated 'inject_tag' used")
+				}
+
 				currentTag := field.Tag.Value
 				area := textArea{
 					Start:      int(field.Pos()),

--- a/main.go
+++ b/main.go
@@ -9,8 +9,7 @@ import (
 )
 
 func main() {
-	var inputFiles string
-	var xxxTags string
+	var inputFiles, xxxTags string
 	flag.StringVar(&inputFiles, "input", "", "pattern to match input file(s)")
 	flag.StringVar(&xxxTags, "XXX_skip", "", "tags that should be skipped (applies 'tag:\"-\"') for unknown fields (deprecated since protoc-gen-go v1.4.0)")
 	flag.BoolVar(&verbose, "verbose", false, "verbose logging")
@@ -18,6 +17,7 @@ func main() {
 
 	var xxxSkipSlice []string
 	if len(xxxTags) > 0 {
+		logf("warn: deprecated flag '-XXX_skip' used")
 		xxxSkipSlice = strings.Split(xxxTags, ",")
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -19,13 +19,14 @@ func TestTagFromComment(t *testing.T) {
 		comment string
 		tag     string
 	}{
-		{comment: `//@inject_tag: valid:"abc"`, tag: `valid:"abc"`},
-		{comment: `//   @inject_tag: valid:"abcd"`, tag: `valid:"abcd"`},
-		{comment: `// @inject_tag:      valid:"xyz"`, tag: `valid:"xyz"`},
+		{comment: `//@gotags: valid:"abc"`, tag: `valid:"abc"`},
+		{comment: `//   @gotags: valid:"abcd"`, tag: `valid:"abcd"`},
+		{comment: `// @gotags:      valid:"xyz"`, tag: `valid:"xyz"`},
 		{comment: `// fdsafsa`, tag: ""},
-		{comment: `//@inject_tag:`, tag: ""},
-		{comment: `// @inject_tag: json:"abc" yaml:"abc`, tag: `json:"abc" yaml:"abc`},
-		{comment: `// test @inject_tag: json:"abc" yaml:"abc`, tag: `json:"abc" yaml:"abc`},
+		{comment: `//@gotags:`, tag: ""},
+		{comment: `// @gotags: json:"abc" yaml:"abc`, tag: `json:"abc" yaml:"abc`},
+		{comment: `// test @gotags: json:"abc" yaml:"abc`, tag: `json:"abc" yaml:"abc`},
+		{comment: `// test @inject_tags: json:"abc" yaml:"abc`, tag: `json:"abc" yaml:"abc`},
 	}
 	for _, test := range tests {
 		result := tagFromComment(test.comment)
@@ -46,7 +47,6 @@ func TestParseWriteFile(t *testing.T) {
 		t.Fatalf("expected 9 areas to replace, got: %d", len(areas))
 	}
 	area := areas[0]
-	t.Logf("area: %v", area)
 	if area.InjectTag != expectedTag {
 		t.Errorf("expected tag: %q, got: %q", expectedTag, area.InjectTag)
 	}

--- a/pb/test.pb.go
+++ b/pb/test.pb.go
@@ -27,7 +27,7 @@ type IP struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Address string `protobuf:"bytes,1,opt,name=Address,proto3" json:"Address,omitempty"` // @inject_tag: valid:"ip" yaml:"ip" json:"overrided"
+	Address string `protobuf:"bytes,1,opt,name=Address,proto3" json:"Address,omitempty"` // @gotags: valid:"ip" yaml:"ip" json:"overrided"
 }
 
 func (x *IP) Reset() {
@@ -79,10 +79,11 @@ type URL struct {
 	// resulting struct field, you should see `valid:"http|https"` added, not
 	// `valid:"-"`.
 	//
-	// @inject_tag: valid:"-"
-	Scheme string `protobuf:"bytes,1,opt,name=scheme,proto3" json:"scheme,omitempty"` // @inject_tag: valid:"http|https"
+	// @gotags: valid:"-"
+	Scheme string `protobuf:"bytes,1,opt,name=scheme,proto3" json:"scheme,omitempty"` // @gotags: valid:"http|https"
 	Url    string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
-	// @inject_tag: valid:"nonzero"
+	// Test legacy field name.
+	// @inject_tags: valid:"nonzero"
 	Port int32 `protobuf:"varint,3,opt,name=port,proto3" json:"port,omitempty"`
 }
 
@@ -144,7 +145,7 @@ type Params struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// @inject_tag: validate:"omitempty"
+	// @gotags: validate:"omitempty"
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// gets converted into XXX_Deprecated, for use with testing pre-v1.4.x protoc-gen-go
 	// functionality that exposes unknown fields as public.
@@ -202,7 +203,7 @@ type Record struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// @inject_tag: validate:"omitempty"
+	// @gotags: validate:"omitempty"
 	Id        string       `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	TestAny   *any.Any     `protobuf:"bytes,2,opt,name=test_any,json=testAny,proto3" json:"test_any,omitempty"`
 	TestEmpty *empty.Empty `protobuf:"bytes,3,opt,name=test_empty,json=testEmpty,proto3" json:"test_empty,omitempty"`
@@ -266,7 +267,7 @@ type OneOfObject struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// @inject_tag: tag:"foo_bar"
+	// @gotags: tag:"foo_bar"
 	//
 	// Types that are assignable to FooBar:
 	//	*OneOfObject_Foo
@@ -332,12 +333,12 @@ type isOneOfObject_FooBar interface {
 }
 
 type OneOfObject_Foo struct {
-	// @inject_tag: tag:"foo"
+	// @gotags: tag:"foo"
 	Foo string `protobuf:"bytes,1,opt,name=foo,proto3,oneof"`
 }
 
 type OneOfObject_Bar struct {
-	// @inject_tag: tag:"bar"
+	// @gotags: tag:"bar"
 	Bar int64 `protobuf:"varint,2,opt,name=bar,proto3,oneof"`
 }
 

--- a/pb/test.proto
+++ b/pb/test.proto
@@ -7,7 +7,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
 message IP {
-  string Address = 1; // @inject_tag: valid:"ip" yaml:"ip" json:"overrided"
+  string Address = 1; // @gotags: valid:"ip" yaml:"ip" json:"overrided"
 }
 
 message URL {
@@ -16,10 +16,11 @@ message URL {
   // resulting struct field, you should see `valid:"http|https"` added, not
   // `valid:"-"`.
   //
-  // @inject_tag: valid:"-"
-  string scheme = 1; // @inject_tag: valid:"http|https"
+  // @gotags: valid:"-"
+  string scheme = 1; // @gotags: valid:"http|https"
   string url = 2;
-  // @inject_tag: valid:"nonzero"
+  // Test legacy field name.
+  // @inject_tags: valid:"nonzero"
   int32 port = 3;
 }
 
@@ -28,7 +29,7 @@ service StreamService {
 }
 
 message Params {
-  // @inject_tag: validate:"omitempty"
+  // @gotags: validate:"omitempty"
   string id = 1;
   // gets converted into XXX_Deprecated, for use with testing pre-v1.4.x protoc-gen-go
   // functionality that exposes unknown fields as public.
@@ -36,18 +37,18 @@ message Params {
 }
 
 message Record {
-  // @inject_tag: validate:"omitempty"
+  // @gotags: validate:"omitempty"
   string id = 1;
   google.protobuf.Any test_any = 2;
   google.protobuf.Empty test_empty = 3;
 }
 
 message OneOfObject {
-  // @inject_tag: tag:"foo_bar"
+  // @gotags: tag:"foo_bar"
   oneof foo_bar {
-    // @inject_tag: tag:"foo"
+    // @gotags: tag:"foo"
     string foo = 1;
-    // @inject_tag: tag:"bar"
+    // @gotags: tag:"bar"
     int64 bar = 2;
   }
 }


### PR DESCRIPTION
- Add support for (and recommend as the new default) `@gotags` field.
- `@inject_tag` is still supported, however users should use `@gotags` moving forward.

```proto
// file: test.proto
syntax = "proto3";

package pb;
option go_package = "/pb";

message IP {
  // @gotags: valid:"ip"
  string Address = 1;

  // Or:
  string MAC = 2; // @gotags: validate:"omitempty"
}
```

------------
closes #45