### PR TITLE
fix tag parse error(support \ in value)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _testmain.go
 **/vendor
 
 protoc-go-inject-tag
+
+.idea

--- a/parse.go
+++ b/parse.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -19,6 +20,60 @@ type tagItem struct {
 }
 
 type tagItems []tagItem
+
+//copy from reflect/type.go
+func parseTag(tag string) (tagItems, error) {
+	ans := tagItems{}
+
+	for tag != "" {
+		// Skip leading space.
+		i := 0
+		for i < len(tag) && tag[i] == ' ' {
+			i++
+		}
+		tag = tag[i:]
+		if tag == "" {
+			break
+		}
+
+		// Scan to colon. A space, a quote or a control character is a syntax error.
+		// Strictly speaking, control chars include the range [0x7f, 0x9f], not just
+		// [0x00, 0x1f], but in practice, we ignore the multi-byte control characters
+		// as it is simpler to inspect the tag's bytes than the tag's runes.
+		i = 0
+		for i < len(tag) && tag[i] > ' ' && tag[i] != ':' && tag[i] != '"' && tag[i] != 0x7f {
+			i++
+		}
+		if i == 0 || i+1 >= len(tag) || tag[i] != ':' || tag[i+1] != '"' {
+			break
+		}
+		name := string(tag[:i])
+		tag = tag[i+1:]
+
+		// Scan quoted string to find value.
+		i = 1
+		for i < len(tag) && tag[i] != '"' {
+			if tag[i] == '\\' {
+				i++
+			}
+			i++
+		}
+		if i >= len(tag) {
+			break
+		}
+
+		//different from reflect/type.go
+		value := string(tag[:i+1])
+		tag = tag[i+1:]
+
+		ans = append(ans, tagItem{
+			key:   name,
+			value: value,
+		})
+	}
+
+	return ans, nil
+}
 
 func (ti tagItems) format() string {
 	tags := []string{}
@@ -49,15 +104,9 @@ func (ti tagItems) override(nti tagItems) tagItems {
 }
 
 func newTagItems(tag string) tagItems {
-	items := []tagItem{}
-	splitted := rTags.FindAllString(tag, -1)
-
-	for _, t := range splitted {
-		sepPos := strings.Index(t, ":")
-		items = append(items, tagItem{
-			key:   t[:sepPos],
-			value: t[sepPos+1:],
-		})
+	items, err := parseTag(tag)
+	if err != nil {
+		log.Fatal(err)
 	}
 	return items
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+func itemsCmp(items1 tagItems, items2 tagItems) bool  {
+	if len(items1) != len(items2) {
+		return false
+	}
+
+	m1 := map[string]string{}
+	m2 := map[string]string{}
+
+	for _, v := range items1 {
+		m1[v.key] = v.value
+	}
+
+	for _, v := range items2 {
+		m2[v.key] = v.value
+	}
+
+	if len(m1) != len(m2) {
+		return false
+	}
+
+	for k, v := range m1 {
+		if _, ok := m2[k]; !ok || v != m2[k] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestParseTag(t *testing.T) {
+	tags := []string{
+		"valid:\"ip\" yaml:\"ip\"",
+		`valid:"i\"p"`,
+		`valid:"i\"p"  `,
+		`valid:"i\"p"  x`,
+		`valid:"i\"p"  x:`,
+	}
+
+	ans := []tagItems {
+		tagItems{
+			tagItem{"valid", `"ip"`},
+			tagItem{"yaml", `"ip"`},
+		},
+		tagItems{
+			tagItem{"valid", `"i\"p"`},
+		},
+		tagItems{
+			tagItem{"valid", `"i\"p"`},
+		},
+		tagItems{
+			tagItem{"valid", `"i\"p"`},
+		},
+		tagItems{
+			tagItem{"valid", `"i\"p"`},
+		},
+	}
+
+	for i, v := range tags {
+		items, err := parseTag(v)
+		if err != nil {
+			t.Error(err)
+			break
+		}
+		if !itemsCmp(items, ans[i]) {
+			t.Error("parsetag error", items, ans[i])
+			break
+		}
+
+	}
+}


### PR DESCRIPTION
`rTags    = regexp.MustCompile(`[\w_]+:"[^"]+"`)` 

don't support escape character \