### PR TITLE
Update README.md with minor fix for install setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ used for validating fields, omitting fields from JSON data, etc.
 
 - go support for protobuf: `go get -u github.com/golang/protobuf/{proto,protoc-gen-go}`
 
-- `go install github.com/favadi/protoc-go-inject-tag` or download the
+- `go install github.com/favadi/protoc-go-inject-tag@latest` or download the
   binaries from the releases page.
 
 ## Usage


### PR DESCRIPTION
Executing the go install command with a tag like:
`go install github.com/favadi/protoc-go-inject-tag` results in:
```
no required module provides package github.com/favadi/protoc-go-inject-tag; to add it:
        go get github.com/favadi/protoc-go-inject-tag
```